### PR TITLE
Fix output channel hack

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,11 +112,10 @@ export function activate(context: ExtensionContext) {
 
     // Create the language client and start the client.
     let lc = new LanguageClient('Rust Language Server', serverOptions, clientOptions);
+    lcOutputChannel = lc.outputChannel;
 
     let runningDiagnostics = new Counter();
     lc.onReady().then(() => {
-        lcOutputChannel = lc.outputChannel;
-
         lc.onNotification(new NotificationType('rustDocument/diagnosticsBegin'), function(f) {
             runningDiagnostics.increment();
 


### PR DESCRIPTION
With this it seems that output channel settings works as it should.
It works without a problem in a case where server is killed and restarted again, and it shouldn't cause trouble wrt extension activation scope, since the child process should be stopped when the extension is deactivated, and with it it noone should be using `OutputChannel` object, so it should be properly discarded.

We might also consider integrating and using `RevealOutputChannelOn` ([here](https://github.com/Microsoft/vscode-languageserver-node/blob/6dbda9039f5702abaf959076596e187a3c03ddd0/client/src/client.ts#L329-L334)) instead of `HIDE_WINDOW_OUTPUT`.