### PR TITLE
Add workspace_mode configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,16 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show warnings."
+                },
+                "rust.workspace_mode": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "EXPERIMENTAL: Enable workspace support and analyze every package in it."
+                },
+                "rust.analyze_package": {
+                    "type": ["string", "null"],
+                    "default": null,
+                    "description": "if `rust.workspace_mode` is enabled, only the specified package in the workspace will be analyzed."
                 }
             }
         }


### PR DESCRIPTION
This adds missing configuration for the new RLS workspace mode added by https://github.com/rust-lang-nursery/rls/pull/409.