### PR TITLE
Read extension configuration from `contributes.configuration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "version": "0.1.0",
     "publisher": "rust-lang",
     "icon": "rust-icon.png",
-	"galleryBanner": {
-		"color": "#336356",
-		"theme": "dark"
+    "galleryBanner": {
+        "color": "#336356",
+        "theme": "dark"
     },
     "engines": {
         "vscode": "^1.8.0"
@@ -75,6 +75,27 @@
             "type": "object",
             "title": "Rust configuration",
             "properties": {
+                "rust-client.showStdErr": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether RLS stderr will be shown in the output channel along with protocol logs. Requires reloading extension after change."
+                },
+                "rust-client.logToFile": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When set to true, RLS stderr is logged to a file at workspace root level. Requires reloading extension after change."
+                },
+                "rust-client.revealOutputChannelOn": {
+                    "type": "string",
+                    "enum": [
+                        "info",
+                        "warn",
+                        "error",
+                        "never"
+                    ],
+                    "default": "never",
+                    "description": "Specifies message severity on which the output channel will be revealed. Requires reloading extension after change."
+                },
                 "rust.sysroot": {
                     "type": ["string", "null"],
                     "default": null,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,52 @@
+// Copyright 2017 The RLS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+'use strict';
+
+import { workspace, OutputChannel, WorkspaceConfiguration } from 'vscode';
+import { RevealOutputChannelOn } from 'vscode-languageclient';
+
+export namespace RevealOutputChannelOnUtil {
+    export function fromString(value: string): RevealOutputChannelOn {
+        switch (value && value.toLowerCase()) {
+            case 'info':
+                return RevealOutputChannelOn.Info;
+            case 'warn':
+                return RevealOutputChannelOn.Warn;
+            case 'error':
+                return RevealOutputChannelOn.Error;
+            case 'never':
+            default:
+                return RevealOutputChannelOn.Never;
+        }
+    }
+}
+
+export class RLSConfiguration {
+    public readonly showStderrInOutputChannel: boolean;
+    public readonly logToFile: boolean;
+    public readonly revealOutputChannelOn: RevealOutputChannelOn = RevealOutputChannelOn.Never;
+
+    public static loadFromWorkspace(): RLSConfiguration {
+        const configuration = workspace.getConfiguration();
+
+        return new RLSConfiguration(configuration);
+    }
+
+    private constructor(configuration: WorkspaceConfiguration) {
+        this.showStderrInOutputChannel = configuration.get<boolean>('rust-client.showStdErr', false);
+        this.logToFile = configuration.get<boolean>('rust-client.logToFile', false);
+        this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
+    }
+    private static readRevealOutputChannelOn(configuration: WorkspaceConfiguration) {
+        const setting = configuration.get<string>('rust-client.revealOutputChannelOn', 'never');
+		return RevealOutputChannelOnUtil.fromString(setting);
+    }
+}


### PR DESCRIPTION
In short this removes hardcoded `HIDE_WINDOW_OUTPUT` and `LOG_TO_FILE` and reads it from settings.json and clarifies when the output channel will be hidden.

For the context, `OutputChannel` will always show up in the drop-down list if at least there will be one call to `OutputChannel.append`, which can happen regardless if we redirect RLS stderr to it, e.g. when receiving LSP error log message, so I separated `HIDE_WINDOW_OUTPUT` into `showStderrInOutputChannel` and `revealOutputChannelOn` configuration options.

I'm open for changing the configuration names' prefixes from "rls.client" to something else, like the other - "rust". Did it because I wanted to separate what's a configuration for the client, and what's a configuration for the server (which, for the server, right now pulls everything with "rust" prefix, [here](https://github.com/rust-lang-nursery/rls-vscode/compare/master...Xanewok:configuration?expand=1#diff-45327f86d4438556066de133327f4ca2R101), and sends it via protocol on change of it)