### PR TITLE
Add .travis.yml to prepare to enable TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ notifications:
 
 language: node_js
 
+node_js:
+  - 7.4 # Sort with the version bundled in supported vscode.
+
 script:
   - npm run compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+dist: trusty
+sudo: false
+
+notifications:
+  email: false
+
+language: node_js
+
+script:
+  - npm run compile

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "main": "./out/src/extension",
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
+        "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"theme": "dark"
     },
     "engines": {
-        "vscode": "^1.8.0"
+        "vscode": "^1.14.0"
     },
     "license": "(MIT OR Apache-2.0)",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     ],
     "main": "./out/src/extension",
     "scripts": {
-        "vscode:prepublish": "tsc -p ./",
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install"
     },


### PR DESCRIPTION
- This pull request contains the change to upgrade the supported version for vscode to make ci more precise. It might has some risks, but I feel it would not be a large problem because vscode update itself automatically.
- ...And I'm not a people of [rust-lang-nursery](https://github.com/rust-lang-nursery). So someone need to enable TravisCI for this repository.