### PR TITLE
Add "Rust" category to "Deglob imports" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
         ],
         "commands": [{
             "command": "rls.deglob",
-            "title": "Deglob imports"
+            "title": "Deglob imports",
+            "category": "Rust"
         }],
         "configuration": {
             "type": "object",


### PR DESCRIPTION
Related to https://github.com/rust-lang-nursery/rls-vscode/issues/79.

This adds "Rust: " prefix to the displayed command name in the UI and logically groups related commands.