### PR TITLE
Add TravisCI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rust support for Visual Studio Code
 
+[![Build Status](https://travis-ci.org/rust-lang-nursery/rls-vscode.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/rls-vscode)
+
 Adds language support for Rust to Visual Studio Code. Supports:
 
 * code completion


### PR DESCRIPTION
- This is follow up for https://github.com/rust-lang-nursery/rls-vscode/pull/77
- This badge would be turned on if we activate TravisCI for this repository (currently it is disabled.)