### PR TITLE
Bump up TypeScript to 2.4 and enable some compiler options for type-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "vscode-languageclient": "^3.3.0"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
+        "typescript": "^2.4.1",
         "vscode": "^1.1.0",
         "mocha": "^2.3.3",
         "@types/mocha": "^2.2.32",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import { workspace, OutputChannel, WorkspaceConfiguration } from 'vscode';
+import { workspace, WorkspaceConfiguration } from 'vscode';
 import { RevealOutputChannelOn } from 'vscode-languageclient';
 
 export namespace RevealOutputChannelOnUtil {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ import * as child_process from 'child_process';
 import * as fs from 'fs';
 
 import { workspace, ExtensionContext, window, commands, OutputChannel } from 'vscode';
-import { LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, TransportKind, NotificationType, RevealOutputChannelOn } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions, NotificationType, RevealOutputChannelOn } from 'vscode-languageclient';
 import * as is from 'vscode-languageclient/lib/utils/is';
 
 const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
@@ -49,7 +49,7 @@ function makeRlsProcess(lcOutputChannel: OutputChannel | null): Promise<child_pr
         if (CONFIGURATION.logToFile) {
             const logPath = workspace.rootPath + '/rls' + Date.now() + '.log';
             let logStream = fs.createWriteStream(logPath, { flags: 'w+' });
-            logStream.on('open', function (f) {
+            logStream.on('open', function (_f) {
                 childProcess.stderr.addListener("data", function (chunk) {
                     logStream.write(chunk.toString());
                 });
@@ -120,11 +120,11 @@ function warnOnRlsToml() {
 function diagnosticCounter(lc: LanguageClient) {
     let runningDiagnostics = 0;
     lc.onReady().then(() => {
-        lc.onNotification(new NotificationType('rustDocument/diagnosticsBegin'), function(f) {
+        lc.onNotification(new NotificationType('rustDocument/diagnosticsBegin'), function(_f) {
             runningDiagnostics++;
             startSpinner("RLS analysis: working");
         });
-        lc.onNotification(new NotificationType('rustDocument/diagnosticsEnd'), function(f) {
+        lc.onNotification(new NotificationType('rustDocument/diagnosticsEnd'), function(_f) {
             runningDiagnostics--;
             if (runningDiagnostics <= 0) {
                 stopSpinner("RLS analysis: done");
@@ -134,9 +134,9 @@ function diagnosticCounter(lc: LanguageClient) {
 }
 
 function registerCommands(lc: LanguageClient, context: ExtensionContext) {
-    const cmdDisposable = commands.registerTextEditorCommand('rls.deglob', (textEditor, edit) => {
+    const cmdDisposable = commands.registerTextEditorCommand('rls.deglob', (textEditor, _edit) => {
         lc.sendRequest('rustWorkspace/deglob', { uri: textEditor.document.uri.toString(), range: textEditor.selection })
-            .then((result) => {},
+            .then((_result) => {},
                   (reason) => {
                 window.showWarningMessage('deglob command failed: ' + reason);
             });

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -24,7 +24,7 @@ export function runRlsViaRustup(): Promise<child_process.ChildProcess> {
 // Check for the nightly toolchain (and that rustup exists)
 function checkForNightly(): Promise<{}> {
     return new Promise((resolve, reject) => {
-        child_process.exec("rustup toolchain list", (error, stdout, stderr) => {
+        child_process.exec("rustup toolchain list", (error, stdout, _stderr) => {
             if (error) {
                 console.log(error);
                 // rustup not present
@@ -63,7 +63,7 @@ function checkForNightly(): Promise<{}> {
 // Check for rls components.
 function checkForRls(): Promise<void> {
     return new Promise((resolve, reject) => {
-        child_process.exec("rustup component list --toolchain nightly", (error, stdout, stderr) => {
+        child_process.exec("rustup component list --toolchain nightly", (error, stdout, _stderr) => {
             if (error) {
                 console.log(error);
                 // rustup error?

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -61,7 +61,7 @@ function checkForNightly(): Promise<{}> {
 }
 
 // Check for rls components.
-function checkForRls(): Promise<{}> {
+function checkForRls(): Promise<void> {
     return new Promise((resolve, reject) => {
         child_process.exec("rustup component list --toolchain nightly", (error, stdout, stderr) => {
             if (error) {
@@ -89,7 +89,7 @@ function checkForRls(): Promise<{}> {
     });
 }
 
-function installRls(resolve, reject): void {
+function installRls(resolve: () => void, reject: (reason?: any) => void): void {
     startSpinner('Installing RLS components');
     child_process.exec("rustup component add rust-analysis --toolchain nightly", (error, stdout, stderr) => {
         console.log(stdout);

--- a/src/spinner.ts
+++ b/src/spinner.ts
@@ -23,11 +23,13 @@ export function startSpinner(message: string) {
 }
 
 export function stopSpinner(message: string) {
-    clearInterval(spinnerTimer);
+    if (spinnerTimer !== null) {
+        clearInterval(spinnerTimer);
+    }
     spinnerTimer = null;
 
     window.setStatusBarMessage(message);
 }
 
-let spinnerTimer = null;
+let spinnerTimer: NodeJS.Timer | null = null;
 const spinner = ['◐', '◓', '◑', '◒'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
         "sourceMap": true,
         "rootDir": "."
     },
+    "include": [
+        "src/**/*"
+    ],
     "exclude": [
         "node_modules",
         ".vscode-test"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
         "outDir": "out",
         "lib": ["es6"],
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "strict": true
     },
     "include": [
         "src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
         "lib": ["es6"],
         "sourceMap": true,
         "rootDir": ".",
-        "strict": true
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
- [By this change](https://github.com/saneyuki/rls-vscode/commit/e6db20d44ad93a7aea7133ef456129f0d831e607), typescript compiler bans if the source includes unused arguments. However, we can avoid the error with `_` prefix for them.
- This enables [`strict` option](https://www.typescriptlang.org/docs/handbook/compiler-options.html) for typescript compiler. It useful to make our codebase more solid.