### PR TITLE
Remove RevealOutputChannelOnUtil namespace

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,19 +13,17 @@
 import { workspace, WorkspaceConfiguration } from 'vscode';
 import { RevealOutputChannelOn } from 'vscode-languageclient';
 
-export namespace RevealOutputChannelOnUtil {
-    export function fromString(value: string): RevealOutputChannelOn {
-        switch (value && value.toLowerCase()) {
-            case 'info':
-                return RevealOutputChannelOn.Info;
-            case 'warn':
-                return RevealOutputChannelOn.Warn;
-            case 'error':
-                return RevealOutputChannelOn.Error;
-            case 'never':
-            default:
-                return RevealOutputChannelOn.Never;
-        }
+function fromStringToRevealOutputChannelOn(value: string): RevealOutputChannelOn {
+    switch (value && value.toLowerCase()) {
+        case 'info':
+            return RevealOutputChannelOn.Info;
+        case 'warn':
+            return RevealOutputChannelOn.Warn;
+        case 'error':
+            return RevealOutputChannelOn.Error;
+        case 'never':
+        default:
+            return RevealOutputChannelOn.Never;
     }
 }
 
@@ -47,6 +45,6 @@ export class RLSConfiguration {
     }
     private static readRevealOutputChannelOn(configuration: WorkspaceConfiguration) {
         const setting = configuration.get<string>('rust-client.revealOutputChannelOn', 'never');
-		return RevealOutputChannelOnUtil.fromString(setting);
+		return fromStringToRevealOutputChannelOn(setting);
     }
 }


### PR DESCRIPTION
namespace is TypeScript only feature and it's transformed to 'namespace object' pattern for JavaScript.

It was popular and useful for classic browsers. but for nodejs, we should use module per file.