### PR TITLE
Accept hidden "rls.path" and "rls.root" user settings

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,6 +31,17 @@ export class RLSConfiguration {
     public readonly showStderrInOutputChannel: boolean;
     public readonly logToFile: boolean;
     public readonly revealOutputChannelOn: RevealOutputChannelOn = RevealOutputChannelOn.Never;
+    /**
+     * Hidden option that can be specified via `"rls.path"` key (e.g. to `/usr/bin/rls`). If
+     * specified, RLS will be spawned by executing a file at the given path.
+     */
+    public readonly rlsPath: string | null;
+    /**
+     * Hidden option that can be specified via `"rls.root"` key (e.g. to `/home/<user>/rls/repo`).
+     * If specified, RLS will be spawned by executing `cargo run --release` under a given working
+     * directory.
+     */
+    public readonly rlsRoot: string | null;
 
     public static loadFromWorkspace(): RLSConfiguration {
         const configuration = workspace.getConfiguration();
@@ -42,6 +53,9 @@ export class RLSConfiguration {
         this.showStderrInOutputChannel = configuration.get<boolean>('rust-client.showStdErr', false);
         this.logToFile = configuration.get<boolean>('rust-client.logToFile', false);
         this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
+        // Hidden options that are not exposed to the user
+        this.rlsPath = configuration.get('rls.path', null);
+        this.rlsRoot = configuration.get('rls.root', null);
     }
     private static readRevealOutputChannelOn(configuration: WorkspaceConfiguration) {
         const setting = configuration.get<string>('rust-client.revealOutputChannelOn', 'never');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,8 +24,10 @@ import * as is from 'vscode-languageclient/lib/utils/is';
 const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
 
 function makeRlsProcess(lcOutputChannel: OutputChannel | null): Promise<child_process.ChildProcess> {
-    const rls_path = process.env.RLS_PATH;
-    const rls_root = process.env.RLS_ROOT;
+    // Allow to override how RLS is started up. Env vars take precedence over hidden
+    // "rls.path" or "rls.root" user settings.
+    const rls_path = process.env.RLS_PATH || CONFIGURATION.rlsPath;
+    const rls_root = process.env.RLS_ROOT || CONFIGURATION.rlsRoot;
 
     let childProcessPromise: Promise<child_process.ChildProcess>;
     if (rls_path) {


### PR DESCRIPTION
With this, specified `"rls.path"` user setting should work the same as if passed RLS_PATH env var, same with `"rls.root"`. However env vars still have bigger priority than user settings.

These options are intentionally not specified in `package.json`, since they're dev-only and would confuse the user. This allows to dynamically specify which RLS to run, which is useful when working on the RLS as well.