### PR TITLE
Create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+### 0.2.0 - 2017-08-07
+
+* Unicode (fixed width) spinner
+* Logging and debugging options in configuration
+* Deglob command is in the Rust category
+* Don't check tests by default (still configurable)
+* Set `RUST_SRC_PATH` for Racer
+* Travis CI for the repo
+* Performance and robustness improvements in the RLS, support for required options
+  here, including
+  - blacklist large and non-very useful crates (configurable)
+  - configure compiler data
+  - don't error on missing options
+  - stabilise renaming
+  - don't crash on non-file URLs
+  - Racer and Rustfmt updates
+  - only use Racer for code completion (never for 'goto def', still configurable)
+  - improve startup build/index time
+  - handle stale compiler data better
+  - add an option to only build/index on save (not on change)
+  - rebuild if Cargo.toml changes
+
+### 0.1.0 - 2017-07-17
+
+* First release

--- a/README.md
+++ b/README.md
@@ -123,31 +123,3 @@ manage building. Both Cargo and rustc are run in-process by the RLS. Formatting
 and code completion are provided by rustfmt and Racer, again both of these are
 run in-process by the RLS.
 
-
-## Changelog
-
-### 0.2.0 - 2017-08-07
-
-* Unicode (fixed width) spinner
-* Logging and debugging options in configuration
-* Deglob command is in the Rust category
-* Don't check tests by default (still configurable)
-* Set `RUST_SRC_PATH` for Racer
-* Travis CI for the repo
-* Performance and robustness improvements in the RLS, support for required options
-  here, including
-  - blacklist large and non-very useful crates (configurable)
-  - configure compiler data
-  - don't error on missing options
-  - stabilise renaming
-  - don't crash on non-file URLs
-  - Racer and Rustfmt updates
-  - only use Racer for code completion (never for 'goto def', still configurable)
-  - improve startup build/index time
-  - handle stale compiler data better
-  - add an option to only build/index on save (not on change)
-  - rebuild if Cargo.toml changes
-
-### 0.1.0 - 2017-07-17
-
-* First release


### PR DESCRIPTION
According to [Publishing Visual Studio Code Extensions](https://code.visualstudio.com/docs/extensions/publish-extension#_marketplace-integration):
> A `CHANGELOG.md` file at the root of your extension will be used as the contents for the extension's change log.

Moved the changelog from `README.md` to `CHANGELOG.md`. With this the changelog can be accessed via *Changelog* tab in the extension preview window.