### PR TITLE
fix typo in rust-analysis to get auto install working

### DIFF
--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -124,7 +124,7 @@ async function installRls(): Promise<void> {
     };
 
     {
-        const e = await tryFn('rust-analysys');
+        const e = await tryFn('rust-analysis');
         if (e !== null) {
             stopSpinner('Could not install RLS');
             throw e;


### PR DESCRIPTION
This caused the extension to fail mysteriously when installing components. Error handling here should likely be improved.