### PR TITLE
Add problem matchers to highlight compilation errors in editor view/minimap.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,31 +144,63 @@ function registerCommands(lc: LanguageClient, context: ExtensionContext) {
     context.subscriptions.push(cmdDisposable);
 }
 
+var defaultProblemMatcher = {
+    "fileLocation": ["relative", "${workspaceRoot}"],
+    "pattern": [{
+            "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+            "severity": 1,
+            "message": 4,
+            //The error code of the error, if available.
+            //Not all errors will have a code reported.
+            "code": 3
+        },
+        {
+            "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+            "file": 2,
+            "line": 3,
+            "column": 4
+        },
+        {
+            "regexp": "^.*$"
+        },
+        {
+            "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+            "file": 2,
+            "line": 3,
+            "column": 4
+        }
+    ]
+};
+
 function addBuildCommands() {
     const config = workspace.getConfiguration();
     if (!config['tasks']) {
         const tasks = {
-            "version": "0.1.0",
+            //Using the post VSC 1.14 task schema.
+            "version": "2.0.0",
             "command": "cargo",
-            "isShellCommand": true,
-            "showOutput": "always",
+            "type": "shell",
+            "presentation" : { "reveal": "always", "panel":"new" },
             "suppressTaskName": true,
             "tasks": [
                 {
                     "taskName": "cargo build",
                     "args": ["build"],
-                    "isBuildCommand": true
+                    "group": "build",
+                    "problemMatcher": defaultProblemMatcher
                 },
                 {
                     "taskName": "cargo run",
-                    "args": ["run"]
+                    "args": ["run"],
+                    "problemMatcher": defaultProblemMatcher
                 },
                 {
                     "taskName": "cargo test",
                     "args": ["test"],
-                    "isTestCommand": true
+                    "group": "test",
+                    "problemMatcher": defaultProblemMatcher
                 }
-            ],
+            ]
         };
         config.update('tasks', tasks, false)
     }


### PR DESCRIPTION
It looks like the current build/test/check tasks don't supply a problem matcher, so errors are displayed in the output tab but aren't highlighted in the main editor/minimap. This matcher can't quite match notes, and I didn't want to switch output to JSON, so this change only matches errors and warnings.