### PR TITLE
Allow for `build_lib` config value to be null

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,9 +131,12 @@
                     "description": "Clear the RUST_LOG environment variable before running rustc or cargo."
                 },
                 "rust.build_lib": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "cargo check --lib"
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "Specify to run analysis as if running `cargo check --lib`. Use `null` to auto-detect."
                 },
                 "rust.build_bin": {
                     "type": [
@@ -141,7 +144,7 @@
                         "null"
                     ],
                     "default": null,
-                    "description": "cargo check --bin <name>"
+                    "description": "Specify to run analysis as if running `cargo check --bin <name>`. Use `null` to auto-detect."
                 },
                 "rust.cfg_test": {
                     "type": "boolean",


### PR DESCRIPTION
Needed for https://github.com/rust-lang-nursery/rls/pull/438 (option can be specified as `true`/`false` or set to `null` to use the crate target auto-detect).