### PR TITLE
Offer find implementations in the menus 

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,23 @@
                 "command": "rls.deglob",
                 "title": "Deglob imports",
                 "category": "Rust"
+            },
+            {
+                "command": "rls.findImpls",
+                "title": "Find Implementations",
+                "description": "Show impl blocks for trait, struct, or enum",
+                "category": "Rust"
             }
         ],
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "rls.findImpls",
+                    "when": "editorLangId == rust && editorHasReferenceProvider",
+                    "group": "navigation@4"
+                }
+            ]
+        },
         "configuration": {
             "type": "object",
             "title": "Rust configuration",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,7 +159,7 @@ function diagnosticCounter(lc: LanguageClient) {
 }
 
 function registerCommands(lc: LanguageClient, context: ExtensionContext) {
-    let cmdDisposable = commands.registerTextEditorCommand('rls.deglob', (textEditor, _edit) => {
+    const cmdDisposable = commands.registerTextEditorCommand('rls.deglob', (textEditor, _edit) => {
         lc.sendRequest('rustWorkspace/deglob', { uri: textEditor.document.uri.toString(), range: textEditor.selection })
             .then((_result) => {},
                   (reason) => {
@@ -168,17 +168,16 @@ function registerCommands(lc: LanguageClient, context: ExtensionContext) {
     });
     context.subscriptions.push(cmdDisposable);
 
-    cmdDisposable = commands.registerTextEditorCommand('rls.findImpls', (textEditor: TextEditor, _edit: TextEditorEdit) => {
-        console.log('Trace find implementations');
+    const cmdDisposable2 = commands.registerTextEditorCommand('rls.findImpls', (textEditor: TextEditor, _edit: TextEditorEdit) => {
         let params = lc.code2ProtocolConverter.asTextDocumentPositionParams(textEditor.document, textEditor.selection.active);
-        let respone = lc.sendRequest("rustDocument/implementations", params);
-        respone.then((locations: Location[]) => {
+        let response = lc.sendRequest("rustDocument/implementations", params);
+        response.then((locations: Location[]) => {
             commands.executeCommand("editor.action.showReferences", textEditor.document.uri, textEditor.selection.active, locations.map(lc.protocol2CodeConverter.asLocation));
         }, (reason) => {
             window.showWarningMessage('find implementations failed: ' + reason);
         });
     });
-    context.subscriptions.push(cmdDisposable);
+    context.subscriptions.push(cmdDisposable2);
 }
 
 var defaultProblemMatcher = {


### PR DESCRIPTION
Since my PR just landed for rls I want to remind you that I also have a small modification to the extension. It provides all the glue code to invoke find_impls from Vscode and adds a context menu entry.

If you dislike some of the choices or want to add something (e.g keybindings) feel free to either just push to the PR or cherry-pick and modify it.