### PR TITLE
Make it possible to opt-out to add default build tasks to task.json on opening a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ following commands:
 * `deglob` - replace a glob (`*`) import with an explicit import. E.g., replace
   `use foo::*;` with `use foo::{bar, baz};`. Select only the `*` when running
   the command.
+* `Configure default build tasks` - create `.vscode/tasks.json` with some build tasks.
 
 
 ### Snippets

--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
                 "title": "Find Implementations",
                 "description": "Show impl blocks for trait, struct, or enum",
                 "category": "Rust"
+            },
+            {
+                "command": "rls.configureDefaultTasks",
+                "title": "Configure Default Tasks",
+                "description": "Add default tasks to tasks.json",
+                "category": "Rust"
             }
         ],
         "menus": {

--- a/package.json
+++ b/package.json
@@ -214,6 +214,11 @@
                     ],
                     "default": null,
                     "description": "if `rust.workspace_mode` is enabled, only the specified package in the workspace will be analyzed."
+                },
+                "rust.setup_build_tasks_automatically": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Configure default build tasks automatically on opening a project."
                 }
             }
         }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,6 +31,7 @@ export class RLSConfiguration {
     public readonly showStderrInOutputChannel: boolean;
     public readonly logToFile: boolean;
     public readonly revealOutputChannelOn: RevealOutputChannelOn = RevealOutputChannelOn.Never;
+    public readonly setupBuildTasksAutomatically: boolean;
     /**
      * Hidden option that can be specified via `"rls.path"` key (e.g. to `/usr/bin/rls`). If
      * specified, RLS will be spawned by executing a file at the given path.
@@ -53,6 +54,7 @@ export class RLSConfiguration {
         this.showStderrInOutputChannel = configuration.get<boolean>('rust-client.showStdErr', false);
         this.logToFile = configuration.get<boolean>('rust-client.logToFile', false);
         this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
+        this.setupBuildTasksAutomatically = configuration.get<boolean>('rust.setup_build_tasks_automatically', true);
         // Hidden options that are not exposed to the user
         this.rlsPath = configuration.get('rls.path', null);
         this.rlsRoot = configuration.get('rls.root', null);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -180,68 +180,74 @@ function registerCommands(lc: LanguageClient, context: ExtensionContext) {
     context.subscriptions.push(cmdDisposable2);
 }
 
-var defaultProblemMatcher = {
-    "fileLocation": ["relative", "${workspaceRoot}"],
-    "pattern": [{
-            "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
-            "severity": 1,
-            "message": 4,
-            //The error code of the error, if available.
-            //Not all errors will have a code reported.
-            "code": 3
-        },
-        {
-            "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-            "file": 2,
-            "line": 3,
-            "column": 4
-        },
-        {
-            "regexp": "^.*$"
-        },
-        {
-            "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-            "file": 2,
-            "line": 3,
-            "column": 4
-        }
-    ]
-};
-
 function addBuildCommands() {
     const config = workspace.getConfiguration();
     if (!config['tasks']) {
-        const tasks = {
-            //Using the post VSC 1.14 task schema.
-            "version": "2.0.0",
-            "command": "cargo",
-            "type": "shell",
-            "presentation" : { "reveal": "always", "panel":"new" },
-            "suppressTaskName": true,
-            "tasks": [
-                {
-                    "taskName": "cargo build",
-                    "args": ["build"],
-                    "group": "build",
-                    "problemMatcher": defaultProblemMatcher
-                },
-                {
-                    "taskName": "cargo run",
-                    "args": ["run"],
-                    "problemMatcher": defaultProblemMatcher
-                },
-                {
-                    "taskName": "cargo test",
-                    "args": ["test"],
-                    "group": "test",
-                    "problemMatcher": defaultProblemMatcher
-                },
-                {
-                    "taskName": "cargo clean",
-                    "args": ["clean"]
-                }
-            ]
-        };
+        const tasks = createDefaultTaskConfig();
         config.update('tasks', tasks, false)
     }
+}
+
+function createDefaultTaskConfig(): object {
+    const defaultProblemMatcher = {
+        "fileLocation": ["relative", "${workspaceRoot}"],
+        "pattern": [{
+                "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+                "severity": 1,
+                "message": 4,
+                //The error code of the error, if available.
+                //Not all errors will have a code reported.
+                "code": 3
+            },
+            {
+                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                "file": 2,
+                "line": 3,
+                "column": 4
+            },
+            {
+                "regexp": "^.*$"
+            },
+            {
+                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                "file": 2,
+                "line": 3,
+                "column": 4
+            }
+        ]
+    };
+
+    const tasks = {
+        //Using the post VSC 1.14 task schema.
+        "version": "2.0.0",
+        "command": "cargo",
+        "type": "shell",
+        "presentation" : { "reveal": "always", "panel":"new" },
+        "suppressTaskName": true,
+        "tasks": [
+            {
+                "taskName": "cargo build",
+                "args": ["build"],
+                "group": "build",
+                "problemMatcher": defaultProblemMatcher
+            },
+            {
+                "taskName": "cargo run",
+                "args": ["run"],
+                "problemMatcher": defaultProblemMatcher
+            },
+            {
+                "taskName": "cargo test",
+                "args": ["test"],
+                "group": "test",
+                "problemMatcher": defaultProblemMatcher
+            },
+            {
+                "taskName": "cargo clean",
+                "args": ["clean"]
+            }
+        ]
+    };
+
+    return tasks;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@
 import { runRlsViaRustup } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from "./configuration";
+import { addBuildCommands } from './tasks';
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -182,87 +183,4 @@ function registerCommands(lc: LanguageClient, context: ExtensionContext) {
         addBuildCommands().catch(console.error);
     });
     context.subscriptions.push(cmdDisposable3);   
-}
-
-async function addBuildCommands(): Promise<string | undefined> {
-    const config = workspace.getConfiguration();
-
-    if (!!config['tasks']) {
-        return Promise.resolve(window.showInformationMessage('tasks.json has other tasks. Any tasks are not added.'));
-    }
-
-    try {
-        const tasks = createDefaultTaskConfig();
-        await Promise.resolve(config.update('tasks', tasks, false));
-    }
-    catch (e) {
-        console.error(e);
-        return Promise.resolve(window.showInformationMessage('Could not update tasks.json. Any tasks are not added.'));
-    }
-
-    return Promise.resolve(window.showInformationMessage('Added default build tasks for Rust'));    
-}
-
-function createDefaultTaskConfig(): object {
-    const defaultProblemMatcher = {
-        "fileLocation": ["relative", "${workspaceRoot}"],
-        "pattern": [{
-                "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
-                "severity": 1,
-                "message": 4,
-                //The error code of the error, if available.
-                //Not all errors will have a code reported.
-                "code": 3
-            },
-            {
-                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-                "file": 2,
-                "line": 3,
-                "column": 4
-            },
-            {
-                "regexp": "^.*$"
-            },
-            {
-                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-                "file": 2,
-                "line": 3,
-                "column": 4
-            }
-        ]
-    };
-
-    const tasks = {
-        //Using the post VSC 1.14 task schema.
-        "version": "2.0.0",
-        "command": "cargo",
-        "type": "shell",
-        "presentation" : { "reveal": "always", "panel":"new" },
-        "suppressTaskName": true,
-        "tasks": [
-            {
-                "taskName": "cargo build",
-                "args": ["build"],
-                "group": "build",
-                "problemMatcher": defaultProblemMatcher
-            },
-            {
-                "taskName": "cargo run",
-                "args": ["run"],
-                "problemMatcher": defaultProblemMatcher
-            },
-            {
-                "taskName": "cargo test",
-                "args": ["test"],
-                "group": "test",
-                "problemMatcher": defaultProblemMatcher
-            },
-            {
-                "taskName": "cargo clean",
-                "args": ["clean"]
-            }
-        ]
-    };
-
-    return tasks;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import { runRlsViaRustup } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from "./configuration";
-import { addBuildCommands } from './tasks';
+import { addBuildCommandsOnOpeningProject, addBuildCommandsByUser } from './tasks';
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -128,6 +128,9 @@ export function activate(context: ExtensionContext) {
 
     diagnosticCounter(lc);
     registerCommands(lc, context);
+    if (CONFIGURATION.setupBuildTasksAutomatically) {
+        addBuildCommandsOnOpeningProject();
+    }
 
     const disposable = lc.start();
     context.subscriptions.push(disposable);
@@ -180,7 +183,7 @@ function registerCommands(lc: LanguageClient, context: ExtensionContext) {
     context.subscriptions.push(cmdDisposable2);
 
     const cmdDisposable3 = commands.registerCommand('rls.configureDefaultTasks', () => {
-        addBuildCommands().catch(console.error);
+        addBuildCommandsByUser().catch(console.error);
     });
     context.subscriptions.push(cmdDisposable3);   
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -8,15 +8,37 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-import { workspace, window } from 'vscode';
+import { workspace, window, WorkspaceConfiguration } from 'vscode';
 
-export async function addBuildCommands(): Promise<string | undefined> {
+function getConfiguration(): { config: WorkspaceConfiguration; hasOtherTasks: boolean } {
     const config = workspace.getConfiguration();
+    const hasOtherTasks: boolean = !!config['tasks'];
 
-    if (!!config['tasks']) {
+    return {
+        config,
+        hasOtherTasks,
+    };
+}
+
+export async function addBuildCommandsOnOpeningProject(): Promise<string | undefined> {
+    const { config, hasOtherTasks } = getConfiguration();
+    if (hasOtherTasks) {
+        return;
+    }
+
+    return addBuildCommands(config);
+}
+
+export async function addBuildCommandsByUser(): Promise<string | undefined> {
+    const { config, hasOtherTasks } = getConfiguration();
+    if (hasOtherTasks) {
         return Promise.resolve(window.showInformationMessage('tasks.json has other tasks. Any tasks are not added.'));
     }
 
+    return addBuildCommands(config);
+}
+
+async function addBuildCommands(config: WorkspaceConfiguration): Promise<string | undefined> {
     try {
         const tasks = createDefaultTaskConfig();
         await Promise.resolve(config.update('tasks', tasks, false));

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,0 +1,94 @@
+// Copyright 2017 The RLS Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+import { workspace, window } from 'vscode';
+
+export async function addBuildCommands(): Promise<string | undefined> {
+    const config = workspace.getConfiguration();
+
+    if (!!config['tasks']) {
+        return Promise.resolve(window.showInformationMessage('tasks.json has other tasks. Any tasks are not added.'));
+    }
+
+    try {
+        const tasks = createDefaultTaskConfig();
+        await Promise.resolve(config.update('tasks', tasks, false));
+    }
+    catch (e) {
+        console.error(e);
+        return Promise.resolve(window.showInformationMessage('Could not update tasks.json. Any tasks are not added.'));
+    }
+
+    return Promise.resolve(window.showInformationMessage('Added default build tasks for Rust'));    
+}
+
+function createDefaultTaskConfig(): object {
+    const defaultProblemMatcher = {
+        "fileLocation": ["relative", "${workspaceRoot}"],
+        "pattern": [{
+                "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+                "severity": 1,
+                "message": 4,
+                //The error code of the error, if available.
+                //Not all errors will have a code reported.
+                "code": 3
+            },
+            {
+                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                "file": 2,
+                "line": 3,
+                "column": 4
+            },
+            {
+                "regexp": "^.*$"
+            },
+            {
+                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                "file": 2,
+                "line": 3,
+                "column": 4
+            }
+        ]
+    };
+
+    const tasks = {
+        //Using the post VSC 1.14 task schema.
+        "version": "2.0.0",
+        "command": "cargo",
+        "type": "shell",
+        "presentation" : { "reveal": "always", "panel":"new" },
+        "suppressTaskName": true,
+        "tasks": [
+            {
+                "taskName": "cargo build",
+                "args": ["build"],
+                "group": "build",
+                "problemMatcher": defaultProblemMatcher
+            },
+            {
+                "taskName": "cargo run",
+                "args": ["run"],
+                "problemMatcher": defaultProblemMatcher
+            },
+            {
+                "taskName": "cargo test",
+                "args": ["test"],
+                "group": "test",
+                "problemMatcher": defaultProblemMatcher
+            },
+            {
+                "taskName": "cargo clean",
+                "args": ["clean"]
+            }
+        ]
+    };
+
+    return tasks;
+}


### PR DESCRIPTION
Motivation
----------------

The previous behavior always create `.vscode/tasks.json` if there is no it.

If the workspace does not contains `.vscode/tasks.json` intentionally by
some reasons (it is not a root dir of the repository, the repository
has not ignored `.vscode` yet, or others), then the previous behavior
force to users to ignore/remove `.vscode/tasks.json` on creating their changesets for the repository.
I'd like to stop it.