### PR TITLE
Various clean up for default tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,36 @@
                 }
             ]
         },
+        "problemMatchers": [
+            {
+                "name": "rustc",
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": [
+                    {
+                        "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
+                        "severity": 1,
+                        "message": 4,
+                        "code": 3
+                    },
+                    {
+                        "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                        "file": 2,
+                        "line": 3,
+                        "column": 4
+                    },
+                    {
+                        "regexp": "^.*$"
+                    },
+                    {
+                        "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
+                        "file": 2,
+                        "line": 3,
+                        "column": 4
+                    }
+                ]
+            }
+        ],
         "configuration": {
             "type": "object",
             "title": "Rust configuration",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -52,34 +52,6 @@ async function addBuildCommands(config: WorkspaceConfiguration): Promise<string 
 }
 
 function createDefaultTaskConfig(): object {
-    const defaultProblemMatcher = {
-        "fileLocation": ["relative", "${workspaceRoot}"],
-        "pattern": [{
-                "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
-                "severity": 1,
-                "message": 4,
-                //The error code of the error, if available.
-                //Not all errors will have a code reported.
-                "code": 3
-            },
-            {
-                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-                "file": 2,
-                "line": 3,
-                "column": 4
-            },
-            {
-                "regexp": "^.*$"
-            },
-            {
-                "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-                "file": 2,
-                "line": 3,
-                "column": 4
-            }
-        ]
-    };
-
     const tasks = {
         //Using the post VSC 1.14 task schema.
         "version": "2.0.0",
@@ -92,18 +64,18 @@ function createDefaultTaskConfig(): object {
                 "taskName": "cargo build",
                 "args": ["build"],
                 "group": "build",
-                "problemMatcher": defaultProblemMatcher
+                "problemMatcher": "$rustc"
             },
             {
                 "taskName": "cargo run",
                 "args": ["run"],
-                "problemMatcher": defaultProblemMatcher
+                "problemMatcher": "$rustc"
             },
             {
                 "taskName": "cargo test",
                 "args": ["test"],
                 "group": "test",
-                "problemMatcher": defaultProblemMatcher
+                "problemMatcher": "$rustc"
             },
             {
                 "taskName": "cargo clean",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -55,30 +55,35 @@ function createDefaultTaskConfig(): object {
     const tasks = {
         //Using the post VSC 1.14 task schema.
         "version": "2.0.0",
-        "command": "cargo",
-        "type": "shell",
         "presentation" : { "reveal": "always", "panel":"new" },
-        "suppressTaskName": true,
         "tasks": [
             {
                 "taskName": "cargo build",
+                "type": "shell",
+                "command": "cargo",
                 "args": ["build"],
                 "group": "build",
                 "problemMatcher": "$rustc"
             },
             {
                 "taskName": "cargo run",
+                "type": "shell",
+                "command": "cargo",
                 "args": ["run"],
                 "problemMatcher": "$rustc"
             },
             {
                 "taskName": "cargo test",
+                "type": "shell",
+                "command": "cargo",
                 "args": ["test"],
                 "group": "test",
                 "problemMatcher": "$rustc"
             },
             {
                 "taskName": "cargo clean",
+                "type": "shell",
+                "command": "cargo",
                 "args": ["clean"]
             }
         ]


### PR DESCRIPTION
Now, we can access to the problem matchers via `$rustc` alias. This is useful to reuse it for user defined tasks!