### PR TITLE
Proposal: Use workspace.registerTaskProvider() to provide default tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ following commands:
 * `deglob` - replace a glob (`*`) import with an explicit import. E.g., replace
   `use foo::*;` with `use foo::{bar, baz};`. Select only the `*` when running
   the command.
-* `Configure default build tasks` - create `.vscode/tasks.json` with some build tasks.
 
 
 ### Snippets

--- a/package.json
+++ b/package.json
@@ -166,11 +166,6 @@
                     "default": false,
                     "description": "Update the RLS whenever the extension starts up."
                 },
-                "rust-client.setup_build_tasks_automatically": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Configure default build tasks automatically on opening a project."
-                },
                 "rust.sysroot": {
                     "type": [
                         "string",

--- a/package.json
+++ b/package.json
@@ -82,12 +82,6 @@
                 "category": "Rust"
             },
             {
-                "command": "rls.configureDefaultTasks",
-                "title": "Configure Default Tasks",
-                "description": "Add default tasks to tasks.json",
-                "category": "Rust"
-            },
-            {
                 "command": "rls.update",
                 "title": "Update the RLS",
                 "description": "Use Rustup to update Rust, the RLS, and required data",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -32,7 +32,6 @@ export class RLSConfiguration {
     public readonly logToFile: boolean;
     public readonly revealOutputChannelOn: RevealOutputChannelOn = RevealOutputChannelOn.Never;
     public readonly updateOnStartup: boolean;
-    public readonly setupBuildTasksAutomatically: boolean;
     /**
      * Hidden option that can be specified via `"rls.path"` key (e.g. to `/usr/bin/rls`). If
      * specified, RLS will be spawned by executing a file at the given path.
@@ -56,7 +55,6 @@ export class RLSConfiguration {
         this.logToFile = configuration.get<boolean>('rust-client.logToFile', false);
         this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
         this.updateOnStartup = configuration.get<boolean>('rust-client.updateOnStartup', true);
-        this.setupBuildTasksAutomatically = configuration.get<boolean>('rust-client.setup_build_tasks_automatically', true);
         // Hidden options that are not exposed to the user
         this.rlsPath = configuration.get('rls.path', null);
         this.rlsRoot = configuration.get('rls.root', null);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import { runRlsViaRustup, rustupUpdate } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from "./configuration";
-import { addBuildCommandsByUser, activateTaskProvider, deactivateTaskProvider } from './tasks';
+import { activateTaskProvider, deactivateTaskProvider } from './tasks';
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -194,11 +194,6 @@ function registerCommands(lc: LanguageClient, context: ExtensionContext) {
         });
     });
     context.subscriptions.push(findImplsDisposable);
-
-    const configureTasksDisposable = commands.registerCommand('rls.configureDefaultTasks', () => {
-        addBuildCommandsByUser().catch(console.error);
-    });
-    context.subscriptions.push(configureTasksDisposable);
 
     const rustupUpdateDisposable = commands.registerCommand('rls.update', () => {
         rustupUpdate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import { runRlsViaRustup, rustupUpdate } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from "./configuration";
-import { addBuildCommandsOnOpeningProject, addBuildCommandsByUser } from './tasks';
+import { addBuildCommandsOnOpeningProject, addBuildCommandsByUser, activateTaskProvider, deactivateTaskProvider } from './tasks';
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -135,8 +135,16 @@ export function activate(context: ExtensionContext) {
         addBuildCommandsOnOpeningProject();
     }
 
+    activateTaskProvider();
+
     const disposable = lc.start();
     context.subscriptions.push(disposable);
+}
+
+export function deactivate(): Promise<void> {
+    deactivateTaskProvider();
+
+    return Promise.resolve();
 }
 
 function warnOnRlsToml() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@
 import { runRlsViaRustup, rustupUpdate } from './rustup';
 import { startSpinner, stopSpinner } from './spinner';
 import { RLSConfiguration } from "./configuration";
-import { addBuildCommandsOnOpeningProject, addBuildCommandsByUser, activateTaskProvider, deactivateTaskProvider } from './tasks';
+import { addBuildCommandsByUser, activateTaskProvider, deactivateTaskProvider } from './tasks';
 
 import * as child_process from 'child_process';
 import * as fs from 'fs';
@@ -131,10 +131,6 @@ export function activate(context: ExtensionContext) {
 
     diagnosticCounter(lc);
     registerCommands(lc, context);
-    if (CONFIGURATION.setupBuildTasksAutomatically) {
-        addBuildCommandsOnOpeningProject();
-    }
-
     activateTaskProvider();
 
     const disposable = lc.start();

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -19,60 +19,8 @@ import {
     TaskRevealKind,
     ShellExecution,
     ShellExecutionOptions,
-    window,
     workspace,
-    WorkspaceConfiguration,
 } from 'vscode';
-
-function getConfiguration(): { config: WorkspaceConfiguration; hasOtherTasks: boolean } {
-    const config = workspace.getConfiguration();
-    const hasOtherTasks: boolean = !!config['tasks'];
-
-    return {
-        config,
-        hasOtherTasks,
-    };
-}
-
-export async function addBuildCommandsByUser(): Promise<string | undefined> {
-    const { config, hasOtherTasks } = getConfiguration();
-    if (hasOtherTasks) {
-        return Promise.resolve(window.showInformationMessage('tasks.json has other tasks. Any tasks are not added.'));
-    }
-
-    return addBuildCommands(config);
-}
-
-async function addBuildCommands(config: WorkspaceConfiguration): Promise<string | undefined> {
-    try {
-        const tasks = createDefaultTaskConfig();
-        await Promise.resolve(config.update('tasks', tasks, false));
-    }
-    catch (e) {
-        console.error(e);
-        return Promise.resolve(window.showInformationMessage('Could not update tasks.json. Any tasks are not added.'));
-    }
-
-    return Promise.resolve(window.showInformationMessage('Added default build tasks for Rust'));
-}
-
-function createDefaultTaskConfig(): object {
-    const tasks = createTaskConfigItem().map((config) => {
-        const def = config.definition as any; // XXX: cast to any to create an arbitary object.
-        def.problemMatcher = config.problemMatcher;
-        // FIXME: set `presentation` option which is created from config.presentationOptions
-        return def;
-    });
-
-    const r = {
-        //Using the post VSC 1.14 task schema.
-        "version": "2.0.0",
-        "presentation": { "reveal": "always", "panel": "new" },
-        "tasks": tasks,
-    };
-
-    return r;
-}
 
 let taskProvider: Disposable | null = null;
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -162,7 +162,6 @@ function createTaskConfigItem(): Array<TaskConfigItem> {
                     'clean'
                 ],
             },
-            group: TaskGroup.Clean,
             presentationOptions,
         },
     ];

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -8,7 +8,21 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-import { workspace, window, WorkspaceConfiguration } from 'vscode';
+import {
+    Disposable,
+    TaskProvider,
+    Task,
+    TaskDefinition,
+    TaskGroup,
+    TaskPanelKind,
+    TaskPresentationOptions,
+    TaskRevealKind,
+    ShellExecution,
+    ShellExecutionOptions,
+    window,
+    workspace,
+    WorkspaceConfiguration,
+} from 'vscode';
 
 function getConfiguration(): { config: WorkspaceConfiguration; hasOtherTasks: boolean } {
     const config = workspace.getConfiguration();
@@ -90,4 +104,147 @@ function createDefaultTaskConfig(): object {
     };
 
     return tasks;
+}
+
+let taskProvider: Disposable | null = null;
+
+export function activateTaskProvider(): void {
+    if (taskProvider !== null) {
+        console.log('the task provider has been activated');
+        return;
+    }
+
+    const provider: TaskProvider = {
+        provideTasks: function ()  {
+            // npm or others parse their task definitions. So they need to provide 'autoDetect' feature.
+            //  e,g, https://github.com/Microsoft/vscode/blob/de7e216e9ebcad74f918a025fc5fe7bdbe0d75b2/extensions/npm/src/main.ts
+            // However, cargo.toml does not support to define a new task like them.
+            // So we are not 'autoDetect' feature and the setting for it.
+            return getCargoTasks();
+        },
+        resolveTask(_task: Task): Task | undefined {
+            return undefined;
+        }
+    };
+
+    taskProvider = workspace.registerTaskProvider('rust', provider);
+}
+
+export function deactivateTaskProvider(): void {
+    if (taskProvider !== null) {
+        taskProvider.dispose();
+    }
+}
+
+interface CargoTaskDefinition extends TaskDefinition {
+    // FIXME: By the document, we should add the `taskDefinitions` section to our package.json and use the value of it.
+    type: 'shell';
+    taskName: string;
+    command: string;
+    args: Array<string>;
+}
+
+interface TaskConfigItem {
+    definition: CargoTaskDefinition;
+    problemMatcher?: Array<string>;
+    group?: TaskGroup;
+    presentationOptions?: TaskPresentationOptions;
+}
+
+function getCargoTasks(): Array<Task> {
+    const problemMatcher = ['$rustc'];
+
+    const presentationOptions: TaskPresentationOptions = {
+        reveal: TaskRevealKind.Always,
+        panel: TaskPanelKind.New,
+    };
+
+    const taskList: Array<TaskConfigItem> = [
+        {
+            definition: {
+                taskName: 'cargo build',
+                type: 'shell',
+                command: 'cargo',
+                args: [
+                    'build'
+                ],
+            },
+            problemMatcher,
+            group: TaskGroup.Build,
+            presentationOptions,
+        },
+        {
+            definition: {
+                taskName: 'cargo run',
+                type: 'shell',
+                command: 'cargo',
+                args: [
+                    'run'
+                ],
+            },
+            problemMatcher,
+            group: TaskGroup.Build,
+            presentationOptions,
+        },
+        {
+            definition: {
+                taskName: 'cargo test',
+                type: 'shell',
+                command: 'cargo',
+                args: [
+                    'test'
+                ],
+            },
+            problemMatcher,
+            group: TaskGroup.Test,
+            presentationOptions,
+        },
+        {
+            definition: {
+                taskName: 'cargo clean',
+                type: 'shell',
+                command: 'cargo',
+                args: [
+                    'clean'
+                ],
+            },
+            group: TaskGroup.Clean,
+            presentationOptions,
+        },
+    ];
+
+    const rootPath = workspace.rootPath;
+    if (rootPath === undefined) {
+        console.error('`workspace.rootPath` is `undefined`');
+        return [];
+    }
+
+    const list = taskList.map((def) => {
+        const t = createTask(rootPath, def);
+        return t;
+    });
+
+    return list;
+}
+
+function createTask(rootPath: string, { definition, group, presentationOptions, problemMatcher }: TaskConfigItem): Task {
+    const TASK_SOURCE = 'Rust';
+
+    const execCmd = `${definition.command} ${definition.args.join(' ')}`;
+    const execOption: ShellExecutionOptions = {
+        cwd: rootPath,
+    };
+    const exec = new ShellExecution(execCmd, execOption);
+
+    const t = new Task(definition, definition.taskName, TASK_SOURCE, exec, problemMatcher);
+
+    if (group !== undefined) {
+        t.group = group;
+    }
+
+    if (presentationOptions !== undefined) {
+        t.presentationOptions = presentationOptions;
+    }
+
+    return t;
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -34,15 +34,6 @@ function getConfiguration(): { config: WorkspaceConfiguration; hasOtherTasks: bo
     };
 }
 
-export async function addBuildCommandsOnOpeningProject(): Promise<string | undefined> {
-    const { config, hasOtherTasks } = getConfiguration();
-    if (hasOtherTasks) {
-        return;
-    }
-
-    return addBuildCommands(config);
-}
-
 export async function addBuildCommandsByUser(): Promise<string | undefined> {
     const { config, hasOtherTasks } = getConfiguration();
     if (hasOtherTasks) {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -62,7 +62,7 @@ interface CargoTaskDefinition extends TaskDefinition {
 
 interface TaskConfigItem {
     definition: CargoTaskDefinition;
-    problemMatcher?: Array<string>;
+    problemMatcher: Array<string>;
     group?: TaskGroup;
     presentationOptions?: TaskPresentationOptions;
 }
@@ -162,6 +162,7 @@ function createTaskConfigItem(): Array<TaskConfigItem> {
                     'clean'
                 ],
             },
+            problemMatcher: [],
             presentationOptions,
         },
     ];

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -138,7 +138,6 @@ function createTaskConfigItem(): Array<TaskConfigItem> {
                 ],
             },
             problemMatcher,
-            group: TaskGroup.Build,
             presentationOptions,
         },
         {


### PR DESCRIPTION
## Summary

I found vscode extension API provides [`workspace.registerTaskProvider()`](https://code.visualstudio.com/docs/extensionAPI/vscode-api) to register tasks which are shown if we run "Tasks: Run Tasks" from vscode's command palette.

If we use it, we can do these:

- Provide more seemless default  tasks.
- Remove `rust-client.setup_build_tasks_automatically` introduced in https://github.com/rust-lang-nursery/rls-vscode/pull/126
    - We did not need introduce it If I found `workspace.registerTaskProvider()` when I had worked on it. Sorry.
- Remove "Add default tasks to tasks.json" command  introduced in https://github.com/rust-lang-nursery/rls-vscode/pull/126
    - We can setup them from:
        1. Do "Tasks: Run Tasks" command
        2. Select "tasks name" and click the configuration (gear) icon.