### PR TITLE
Prevent error when rustc is not in $PATH

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,9 @@ import * as is from 'vscode-languageclient/lib/utils/is';
 const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
 
 function getSysroot(env: Object): string | Error {
-    const rustcSysroot = child_process.spawnSync('rustc', ['--print', 'sysroot'], { env });
+    const rustcSysroot = child_process.spawnSync(
+        'rustup', ['run', 'nightly', 'rustc', '--print', 'sysroot'], {env}
+    );
 
     if (rustcSysroot.error) {
         return new Error(`Error running \`rustc\`: ${rustcSysroot.error}`);
@@ -85,7 +87,10 @@ function makeRlsProcess(lcOutputChannel: OutputChannel | null): Promise<child_pr
     if (rls_path) {
         childProcessPromise = Promise.resolve(child_process.spawn(rls_path, [], { env }));
     } else if (rls_root) {
-        childProcessPromise = Promise.resolve(child_process.spawn('cargo', ['run', '--release'], { cwd: rls_root, env }));
+        childProcessPromise = Promise.resolve(child_process.spawn(
+          'rustup', ['run', 'nighty', 'cargo', 'run', '--release'],
+          {cwd: rls_root, env})
+        );
     } else {
         childProcessPromise = runRlsViaRustup(env);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ function getSysroot(env: Object): string | Error {
     if (rustcSysroot.status > 0) {
         return new Error(`Error getting sysroot from \`rustc\`: exited with \`${rustcSysroot.status}\``);
     }
-    
+
     if (!rustcSysroot.stdout || typeof rustcSysroot.stdout.toString !== 'function') {
         return new Error(`Couldn't get sysroot from \`rustc\`: Got no ouput`);
     }
@@ -63,7 +63,8 @@ function makeRlsEnv(): any {
         result = getSysroot(env);
 
         if (result instanceof Error) {
-            console.warn(result);
+            console.warn('Error reading sysroot (second try)', result);
+            window.showWarningMessage('RLS could not set RUST_SRC_PATH for Racer because it could not read the Rust sysroot.');
         }
     }
     if (typeof result === 'string') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,12 +28,15 @@ const CONFIGURATION = RLSConfiguration.loadFromWorkspace();
 // Make an evironment to run the RLS.
 // Tries to synthesise RUST_SRC_PATH for Racer, if one is not already set.
 function makeRlsEnv(): any {
-    const env = process.env;
+    let env = process.env;
+    if (typeof env.HOME === 'string' && env.HOME.length) {
+        env.PATH = `${env.HOME}/.cargo/bin:${env.PATH || ""}`;
+    }
     if (process.env.RUST_SRC_PATH) {
         return env;
     } else {
         // rustc --print sysroot + lib/rustlib/src/rust/src
-        const result = child_process.spawnSync('rustc', ['--print', 'sysroot']);
+        const result = child_process.spawnSync('rustc', ['--print', 'sysroot'], { env });
         if (result.status > 0) {
             console.log('error running rustc for sysroot');
             return env;


### PR DESCRIPTION
...by extending `$PATH` with a common place where rustup drops binaries.

Story time! I keep having this weird issue when opening a Rust project in vscode:

```
TypeError: Cannot read property 'toString' of null
	at makeRlsEnv (/Users/pascal/.vscode-insiders/extensions/rust-lang.rust-0.2.2/out/src/extension.js:44:36)
	at makeRlsProcess (/Users/pascal/.vscode-insiders/extensions/rust-lang.rust-0.2.2/out/src/extension.js:55:17)
	at autoUpdate.then (/Users/pascal/.vscode-insiders/extensions/rust-lang.rust-0.2.2/out/src/extension.js:114:57)
	at <anonymous>
```

Debugging the extension lead me to `src/extension.ts:41` [1], which assumes that the return value of `spawnSync` has a `stdout` property that can be converted to a string. Sadly, this is not always the case: When `spawn` could not find the binary to execute, it returns an object with an `error` property and also `stdout: null`.

I have no clue why it can't find `rustc` on my machine, but I sure have a weird setup. I'm using macOS, my default shell is fish, and this is in version `1.16.0-insider` of vscode. I'm using rustup, and all rust-related binaries are only available locally in `~/.cargo/bin/` from what I can tell.

This change should not cause any trouble---but I have only tested it on macOS. I'm not sure how other system (Windows) handles `$PATH` or even what syntax it expects. If vscode-rust targets Windows, patches to this may be required.

[1]: https://github.com/rust-lang-nursery/rls-vscode/blob/63000e65870f18318615c27a72c683cec05a3cbf/src/extension.ts#L41