### PR TITLE
Update README.md with regards to deglobbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Commands can be found in the command palette (ctrl + shift + p). We provide the
 following commands:
 
 * `deglob` - replace a glob (`*`) import with an explicit import. E.g., replace
-  `use foo::*;` with `use foo::{bar, baz};`. Select only the `*` when running
+  `use foo::*;` with `use foo::{bar, baz};`. Select the `use` line when running
   the command.
 
 


### PR DESCRIPTION
As per https://github.com/rust-lang-nursery/rls/pull/445 we can select a whole line now, in addition to having to select only the `*` character.