### PR TITLE
Set LD_LIBRARY_PATH even when RUST_SRC_PATH is already set. (Don't return early.)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,10 +53,6 @@ function getSysroot(env: Object): string | Error {
 function makeRlsEnv(setLibPath = false): any {
     const env = process.env;
 
-    if (process.env.RUST_SRC_PATH) {
-        return env;
-    }
-
     let result = getSysroot(env);
     if (result instanceof Error) {
         console.info(result.message);
@@ -71,7 +67,9 @@ function makeRlsEnv(setLibPath = false): any {
     }
     if (typeof result === 'string') {
         console.info(`Setting sysroot to`, result);
-        env.RUST_SRC_PATH = result + '/lib/rustlib/src/rust/src';
+        if ( ! process.env.RUST_SRC_PATH) {
+            env.RUST_SRC_PATH = result + '/lib/rustlib/src/rust/src';
+        }
         if (setLibPath) {
             env.DYLD_LIBRARY_PATH = result + '/lib';
             env.LD_LIBRARY_PATH = result + '/lib';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,18 +87,18 @@ function makeRlsProcess(lcOutputChannel: OutputChannel | null): Promise<child_pr
     let childProcessPromise: Promise<child_process.ChildProcess>;
     if (rls_path) {
         const env = makeRlsEnv(true);
-        console.info("running " + rls_path);
+        console.info('running ' + rls_path);
         childProcessPromise = Promise.resolve(child_process.spawn(rls_path, [], { env }));
     } else if (rls_root) {
         const env = makeRlsEnv();
-        console.info("running `cargo run` in " + rls_root);
+        console.info('running `cargo run` in ' + rls_root);
         childProcessPromise = Promise.resolve(child_process.spawn(
           'rustup', ['run', 'nightly', 'cargo', 'run', '--release'],
           {cwd: rls_root, env})
         );
     } else {
         const env = makeRlsEnv();
-        console.info("running with rustup");
+        console.info('running with rustup');
         childProcessPromise = runRlsViaRustup(env);
     }
 


### PR DESCRIPTION
Great timing with this commit! https://github.com/rust-lang-nursery/rls-vscode/commit/14f32304d99885fd2aef8e69d1c20754766ab328 Turns out my RLS would just crash without it, since it load wrong libraries.

However, I had the `RUST_SRC_PATH` environment variable set in my environment, which made `makeRlsEnv` return early and not set `RUST_SRC_PATH`, so I changed that.