### PR TITLE
Add onEnter rules for comments

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,10 +254,16 @@ function configureLanguage(context: ExtensionContext) {
     const disposable = languages.setLanguageConfiguration('rust', {
         onEnterRules: [
             {
-                // Begins a triple-slash doc comment
-                // e.g. ///| or //!|
-                beforeText: /^\s*\/{2}(\/|\!).*$/,
+                // Doc single-line comment
+                // e.g. ///|
+                beforeText: /^\s*\/{3}.*$/,
                 action: { indentAction: IndentAction.None, appendText: '/// ' },
+            },
+            {
+                // Parent doc single-line comment
+                // e.g. //!|
+                beforeText: /^\s*\/{2}\!.*$/,
+                action: { indentAction: IndentAction.None, appendText: '//! ' },
             },
             {
                 // Begins an auto-closed multi-line comment (standard or parent doc)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,7 +142,7 @@ function makeRlsProcess(lcOutputChannel: OutputChannel | null): Promise<child_pr
 let lc : LanguageClient;
 
 export function activate(context: ExtensionContext) {
-    configureLanguage();
+    configureLanguage(context);
     startLanguageClient(context);
     registerCommands(context);
     activateTaskProvider();
@@ -250,8 +250,8 @@ function registerCommands(context: ExtensionContext) {
     context.subscriptions.push(restartServer);
 }
 
-function configureLanguage() {
-    languages.setLanguageConfiguration('rust', {
+function configureLanguage(context: ExtensionContext) {
+    const disposable = languages.setLanguageConfiguration('rust', {
         onEnterRules: [
             {
                 // Begins a triple-slash doc comment
@@ -286,4 +286,5 @@ function configureLanguage() {
               }
         ]
     });
+    context.subscriptions.push(disposable);
 }


### PR DESCRIPTION
This adds the convenience of VSCode's hooks for onEnter events for Rust. Now, when pressing `enter` within a  comment, the comment continues. For example: after typing `///` and pressing `enter`, the next line that the cursor is on will also have `///`, followed by a single space.

`//!`, `/**`, and `/*!` multi-line comments are also supported. Single line comments (`//`), are not continued on `enter`.

This fixes #153.