### PR TITLE
Display warning message if Cargo.toml is missing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,6 +155,8 @@ export function activate(context: ExtensionContext) {
 
 function startLanguageClient(context: ExtensionContext)
 {
+    warnOnMissingCargoToml();
+
     window.setStatusBarMessage('RLS: starting up');
 
     // FIXME(#66): Hack around stderr not being output to the window if ServerOptions is a function
@@ -190,6 +192,14 @@ export function deactivate(): Promise<void> {
     deactivateTaskProvider();
 
     return Promise.resolve();
+}
+
+function warnOnMissingCargoToml() {
+    workspace.findFiles('Cargo.toml').then(files => {
+        if (files.length < 1) {
+            window.showWarningMessage('Cargo.toml must be in the workspace in order to support all features');
+        }
+    });
 }
 
 function warnOnRlsToml() {


### PR DESCRIPTION
If there is no Cargo.toml at the root of the workspace, display a warning message to the user informing them that not all features will be available.

This fixes #75 