### PR TITLE
Deprecate `rust-client.showStdErr` property.

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,11 +142,6 @@
             "type": "object",
             "title": "Rust configuration",
             "properties": {
-                "rust-client.showStdErr": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Specifies whether RLS stderr will be shown in the output channel along with protocol logs. Requires reloading extension after change."
-                },
                 "rust-client.logToFile": {
                     "type": "boolean",
                     "default": false,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -28,7 +28,6 @@ function fromStringToRevealOutputChannelOn(value: string): RevealOutputChannelOn
 }
 
 export class RLSConfiguration {
-    public readonly showStderrInOutputChannel: boolean;
     public readonly logToFile: boolean;
     public readonly revealOutputChannelOn: RevealOutputChannelOn = RevealOutputChannelOn.Never;
     public readonly updateOnStartup: boolean;
@@ -53,7 +52,6 @@ export class RLSConfiguration {
     }
 
     private constructor(configuration: WorkspaceConfiguration) {
-        this.showStderrInOutputChannel = configuration.get<boolean>('rust-client.showStdErr', false);
         this.logToFile = configuration.get<boolean>('rust-client.logToFile', false);
         this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
         this.updateOnStartup = configuration.get<boolean>('rust-client.updateOnStartup', true);


### PR DESCRIPTION
Closes #149.

#148 pulled in a 3.4.2 version of vscode-languageclient, which fixes the bug (#66) with stderr not being properly appended if the server options were a function.
With #148, the property doesn't change the way the extension behaves anymore - it logs the stderr, no matter if the `rust-client.showStdErr` is set or not. The changes here mostly prune what's not required anymore.

Not sure how we should proceed with the deprecated property. Should it stay marked as `@deprecated` in the API? Should we just flat-out remove it and not care? When vscode encounters a property it doesn't recognize, it only highlights it with a warning saying `Unknown configuration setting`, so just removing the property would not break anything for the users.