### PR TITLE
Check for new  `rls-preview` component when detecting RLS components

### DIFF
--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -109,7 +109,9 @@ async function checkForRls(): Promise<void> {
 async function hasRlsComponents(): Promise<boolean> {
     try {
         const { stdout } = await execChildProcess('rustup component list --toolchain ' + CONFIGURATION.channel);
-        if (stdout.search(/^rls.* \((default|installed)\)$/m) === -1 ||
+        const componentName = new RegExp('^' + CONFIGURATION.componentName + '.* \\((default|installed)\\)$', 'm');
+        if (
+            stdout.search(componentName) === -1 ||
             stdout.search(/^rust-analysis.* \((default|installed)\)$/m) === -1 ||
             stdout.search(/^rust-src.* \((default|installed)\)$/m) === -1) {
             return false;


### PR DESCRIPTION
Follows https://github.com/rust-lang-nursery/rls-vscode/commit/ffd9ca4616902850019bd0f07b3e55c1970efeef.
Fixes detecting installed `rls-preview` instead of `rls` (won't say that it's not installed when the user has in fact installed `rls-preview`.

@nrc should we release 0.3.1 with this fix?