### PR TITLE
Use the user's default toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
                 },
                 "rust-client.channel": {
                     "type": "string",
-                    "default": "nightly",
+                    "default": "default",
                     "description": "Rust channel to install RLS from."
                 },
                 "rust-client.rls-name": {


### PR DESCRIPTION
Since Rust 1.21 the RLS can be installed from the stable channel.

Switching to use the stable channel by default would let people who
prefer to depend only on the stable compiler to have nightly installed
for one less thing.