### PR TITLE
Fix typescript error _f implicitly has any type

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,11 +204,11 @@ async function autoUpdate() {
 function diagnosticCounter() {
     let runningDiagnostics = 0;
     lc.onReady().then(() => {
-        lc.onNotification(new NotificationType('rustDocument/beginBuild'), function(_f) {
+        lc.onNotification(new NotificationType('rustDocument/beginBuild'), function(_f: any) {
             runningDiagnostics++;
             startSpinner('RLS: working');
         });
-        lc.onNotification(new NotificationType('rustDocument/diagnosticsEnd'), function(_f) {
+        lc.onNotification(new NotificationType('rustDocument/diagnosticsEnd'), function(_f: any) {
             runningDiagnostics--;
             if (runningDiagnostics <= 0) {
                 stopSpinner('RLS: done');


### PR DESCRIPTION
```
src/extension.ts(207,85): error TS7006: Parameter '_f' implicitly has an 'any' type.
src/extension.ts(211,89): error TS7006: Parameter '_f' implicitly has an 'any' type.
```

I'm new to typescript, but from what I can tell, these errors are completely valid.  You set "strict: true" in tsconfig.json, which sets noImplicitAny.  I tried it with typescript 2.5.3 and 2.6.1 and always get these errors.  Why am I the only one getting these errors?

This PR fixes it.