### PR TITLE
Improve snippet for `if let`

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -40,14 +40,14 @@
         ],
         "description": "Insert macro_rules!"
     },
-    "if let Option": {
+    "if let": {
         "prefix": "if let",
         "body": [
-            "if let Some(${1:foo}) = ${1:foo} {",
-            "\t${0:${1:foo}.}",
+            "if let ${1:Some(foo)} = ${2:bar} {",
+            "\t$0",
             "}"
         ],
-        "description": "Unwrap Option with if let"
+        "description": "Unwrap value with if let"
     },
     "spawn": {
         "prefix": "thread::spawn",


### PR DESCRIPTION
I find the provided `if let` snippet is rather useless. Besides the obvious numbering error, I think offering `foo.` in the if block is not helpful. As such a simple if let snippet, which works will all enums and doesn't suggest anything inside the block would be more helpful.