### PR TITLE
Tell the user that Cargo.toml should be found at the root

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,7 +181,7 @@ export function deactivate(): Promise<void> {
 function warnOnMissingCargoToml() {
     workspace.findFiles('Cargo.toml').then(files => {
         if (files.length < 1) {
-            window.showWarningMessage('Cargo.toml must be in the workspace in order to support all features');
+            window.showWarningMessage('A Cargo.toml file must be at the root of the workspace in order to support all features');
         }
     });
 }


### PR DESCRIPTION
This is a follow-up to the comments in #157
(https://github.com/rust-lang-nursery/rls-vscode/pull/157#issuecomment-348599867)

I changed the message

    Cargo.toml must be in the workspace in order to support all features

to 

    A Cargo.toml file must be at the root of the workspace in order to support all features

so that we are reminded that the Cargo.toml should be at the root
