### PR TITLE
Do not start RLS if a file is opened instead of a folder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,6 +143,10 @@ export function activate(context: ExtensionContext) {
 
 function startLanguageClient(context: ExtensionContext)
 {
+    if (workspace.rootPath === undefined) {
+        window.showWarningMessage('Cannot start RLS because no folder was opened');
+        return;
+    }
     warnOnMissingCargoToml();
 
     window.setStatusBarMessage('RLS: starting up');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,7 +144,7 @@ export function activate(context: ExtensionContext) {
 function startLanguageClient(context: ExtensionContext)
 {
     if (workspace.rootPath === undefined) {
-        window.showWarningMessage('Cannot start RLS because no folder was opened');
+        window.showWarningMessage('Startup error: the RLS can only operate on a folder, not a single file');
         return;
     }
     warnOnMissingCargoToml();


### PR DESCRIPTION
RLS crashes if a file is opened instead of a folder.
This PR checks if that is the case, displays a warning message to the user and does not start the RLS.

RLS has at least two issues of this rust-lang-nursery/rls#628 and rust-lang-nursery/rls#619