### PR TITLE
add link to "Hello, Cargo!" from quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ more details on building and debugging, etc., see [contributing.md](contributing
 * Install [rustup](https://www.rustup.rs/) (Rust toolchain manager).
 * Install this extension from [the VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
   (or by entering `ext install rust` at the command palette).
+* (Skip this step if you already have Rust projects that you'd like to work on.)
+  Create a new Rust project by following [these instructions](https://doc.rust-lang.org/book/second-edition/ch01-02-hello-world.html#creating-a-project-with-cargo).
 * Open a Rust project (`File > Open Folder...`). Open the folder for the whole
   project (i.e., the folder containing 'Cargo.toml'), not the 'src' folder.
 * The extension will start when you open a Rust file. You'll be prompted to


### PR DESCRIPTION
Many beginners seem to get tripped up when the Quick Start says "now open up your Rust project, i.e. the folder containing Cargo.toml" and they're like "I know some of those words". So this adds a link to the book section explaining how to create a new project.