### PR TITLE
feat(configuration): set default channel to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
                 },
                 "rust-client.channel": {
                     "type": "string",
-                    "default": "nightly",
+                    "default": "stable",
                     "description": "Rust channel to install RLS from."
                 },
                 "rust-client.rls-name": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -58,7 +58,7 @@ export class RLSConfiguration {
         this.revealOutputChannelOn = RLSConfiguration.readRevealOutputChannelOn(configuration);
         this.updateOnStartup = configuration.get<boolean>('rust-client.updateOnStartup', true);
 
-        this.channel = configuration.get('rust-client.channel', 'nightly');
+        this.channel = configuration.get('rust-client.channel', 'stable');
         this.componentName = configuration.get('rust-client.rls-name', 'rls');
 
         // Hidden options that are not exposed to the user

--- a/src/rustup.ts
+++ b/src/rustup.ts
@@ -43,7 +43,9 @@ export async function rustupUpdate() {
     }
 }
 
-// Check for the nightly toolchain (and that rustup exists)
+/**
+ * Check for the toolchain from congifuration (and that rustup exists)
+ */
 async function ensureToolchain(): Promise<void> {
     const toolchainInstalled = await hasToolchain();
     if (toolchainInstalled) {


### PR DESCRIPTION
- closes #217 

Feel freely close if this isn't desired direction -  as it's small changes I took stab directly via PR.
This PR changes default channel to stable, prevents rustup update nightly doesn't have rls-preview breaks extension behavior.