### PR TITLE
delete removed settings from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ Some highlights:
 * `rust.build_bin` - if you have multiple binaries, you can specify which to build
   using this option.
 * `rust.cfg_test` - build and index test code (i.e., code with `#[cfg(test)]`/`#[test]`)
-* `rust.workspace_mode` - experimental cargo workspace support. Note that using
-  this feature will slow down builds significantly and may be broken in
-  surprising and undocumented ways.
 
 
 ## Features


### PR DESCRIPTION
due 0.4 code, removed `rust.workspace_mode` settings, but READMD.md outdated.