### PR TITLE
Update @types/node to 8.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.0.28",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-            "integrity": "sha1-hiBnFvjZJRz0FpLjhCZMvXBYrWA=",
+            "version": "8.9.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
+            "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
             "dev": true
         },
         "mocha": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-            "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+            "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
             "dev": true,
             "requires": {
                 "browser-stdout": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.43",
-        "@types/node": "^8.0.28",
+        "@types/node": "^8.0.32",
         "mocha": "^3.5.3",
         "tslint": "^5.7.0",
         "typescript": "^2.5.2",


### PR DESCRIPTION
Fixes #270.
This fixes a ts compilation error, `execFile` types were fixed in https://github.com/DefinitelyTyped/DefinitelyTyped/commit/b66ac3815ab5a32808a10388c0f086bbe4d9a318.

r? @nrc

cc @kdy1 