### PR TITLE
Actually use types for node.js 7.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.9.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.5.tgz",
-            "integrity": "sha512-jRHfWsvyMtXdbhnz5CVHxaBgnV6duZnPlQuRSo/dm/GnmikNcmZhxIES4E9OZjUmQ8C+HCl4KJux+cXN/ErGDQ==",
+            "version": "7.0.56",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.56.tgz",
+            "integrity": "sha512-NgjN3xPyqbAXSIpznNAR5Cisx5uKqJWxcS9kefzSFEX/9J7O01/FHyfnvPI7SztBf9p6c8mqOn3olZWJx3ja6g==",
             "dev": true
         },
         "mocha": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.43",
-        "@types/node": "^8.0.32",
+        "@types/node": "^7.0.56",
         "mocha": "^3.5.3",
         "tslint": "^5.7.0",
         "typescript": "^2.5.2",


### PR DESCRIPTION
Currently VSCode uses Node 7.9 version, so it's safer to pull types for this version instead. Thankfully the compile errors are gone here as well! Sorry for the churn and thanks @kdy1 for spotting the mistake!

r? @nrc 