### PR TITLE
Change `wait_to_build` default value to 1500ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
                 },
                 "rust.wait_to_build": {
                     "type": "number",
-                    "default": 500,
+                    "default": 1500,
                     "description": "Time in milliseconds between receiving a change notification and starting build."
                 },
                 "rust.show_warnings": {


### PR DESCRIPTION
RLS uses now 1500ms: https://github.com/rust-lang-nursery/rls/blob/242762ab99ac3df51b58bd83aa14fc9d83d0300a/src/main.rs#L71

See also https://github.com/rust-lang-nursery/rls/pull/771