### PR TITLE
Add the rust.all_targets configuration value

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Some highlights:
 * `rust.build_bin` - if you have multiple binaries, you can specify which to build
   using this option.
 * `rust.cfg_test` - build and index test code (i.e., code with `#[cfg(test)]`/`#[test]`)
+* `rust.all_targets` - build and index code for all targets (i.e., integration tests, examples, and benches)
 
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -284,6 +284,11 @@
                     ],
                     "default": null,
                     "description": "Number of Cargo jobs to be run in parallel."
+                },
+                "rust.all_targets": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Checks the project as if you were running cargo check --all-targets (I.e., check all targets and integration tests too)."
                 }
             }
         }


### PR DESCRIPTION
Relevant issues #281 #261

The RLS added the `all_targets` option, which builds and indexes code for benches/tests/examples when the flag is set. Currently the RLS does none of that for code in those directories. This PR adds the configuration option in the rls-vscode plugin.