### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,7 +165,10 @@ async function startLanguageClient(context: ExtensionContext) {
     };
     const clientOptions: LanguageClientOptions = {
         // Register the server for Rust files
-        documentSelector: ['rust'],
+        documentSelector: [
+            { language: 'rust', scheme: 'file' },
+            { language: 'rust', scheme: 'untitled' },
+        ],
         synchronize: { configurationSection: 'rust' },
         // Controls when to focus the channel rather than when to reveal it in the drop-down list
         revealOutputChannelOn: CONFIGURATION.revealOutputChannelOn,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,7 @@ async function startLanguageClient(context: ExtensionContext) {
         // Register the server for Rust files
         documentSelector: [
             { language: 'rust', scheme: 'file' },
-            { language: 'rust', scheme: 'untitled' },
+            { language: 'rust', scheme: 'untitled' }
         ],
         synchronize: { configurationSection: 'rust' },
         // Controls when to focus the channel rather than when to reveal it in the drop-down list

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -72,7 +72,6 @@ function getCargoTasks(): Array<Task> {
 
     const rootPath = workspace.rootPath;
     if (rootPath === undefined) {
-        console.error('`workspace.rootPath` is `undefined`');
         return [];
     }
 


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Rust, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Rust extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Rust project using Live Share, and doesn't have the Rust extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Rust extension installed. Additionally, this wouldn't impact the "local" Rust development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*