### PR TITLE
RLS's target_dir should be a subdirectory of target/

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
                         "string",
                         "null"
                     ],
-                    "default": "rls",
+                    "default": "target/rls",
                     "description": "When specified, it places the generated analysis files at the specified target directory. By default it is placed target/rls directory."
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rls/issues/864
This updates the fix in #312