### PR TITLE
Add default channel setting & constrain channel values

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,10 +174,14 @@
                 },
                 "rust-client.channel": {
                     "type": [
-                        "string",
-                        "null"
+                        "string"
                     ],
-                    "default": null,
+                    "enum": [
+                        "stable",
+                        "beta",
+                        "nightly"
+                    ],
+                    "default": "stable",
                     "description": "Rust channel to install RLS from."
                 },
                 "rust-client.rls-name": {

--- a/package.json
+++ b/package.json
@@ -174,15 +174,16 @@
                 },
                 "rust-client.channel": {
                     "type": [
-                        "string"
+                        "string",
+                        null
                     ],
                     "enum": [
                         "stable",
                         "beta",
                         "nightly"
                     ],
-                    "default": "stable",
-                    "description": "Rust channel to install RLS from."
+                    "default": null,
+                    "description": "Rust channel to install RLS from. By default it will use the same channel as your currently open project"
                 },
                 "rust-client.rls-name": {
                     "type": "string",


### PR DESCRIPTION
This pull requests adds autocompletion and a (normal) default for the ``rust-client.channel`` setting.

closes #315 