### PR TITLE
Add assert!() and assert_eq!() snippets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ the following snippets:
 * `unimplemented`
 * `unreachable`
 * `println`
+* `assert` and `assert_eq`
 * `macro_rules` - declare a macro
 * `if let Option` - an `if let` statement for executing code only in the `Some`
   case.

--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -36,6 +36,20 @@
         ],
         "description": "Insert println!"
     },
+    "assert": {
+		"prefix": "assert",
+		"body": [
+			"assert!($1)$0"
+		],
+		"description": "Insert assert!"
+	},
+	"assert_eq": {
+		"prefix": "assert_eq",
+		"body": [
+			"assert_eq!($1, $2)$0"
+		],
+		"description": "Insert assert_eq!"
+	},
     "macro_rules": {
         "prefix": "macro_rules",
         "body": [


### PR DESCRIPTION
As I understand it, RLS relies on Racer for snippet autocompletion [(rls/#827)](https://github.com/rust-lang-nursery/rls/issues/827). But since snippet autocompletion for macros hasn't been implemented yet [(rls/#829)](https://github.com/racer-rust/racer/issues/829), I propose we add two more commonly used macros: `assert!()` and `assert_eq!()` to rls-vscode as a temporary measure.

Later on, when macro autocompletion is implemented we should be able to remove these without breaking anything.