### PR TITLE
1. Add tabstop for `println!` snippet. 2. Fix source code formatting for `assert!` and `assert_eq!` snippets.

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -32,7 +32,7 @@
     "println": {
         "prefix": "println",
         "body": [
-            "println!(\"${1:{\\}}\", $0)"
+            "println!(\"${1:{\\}}\", $2)$0"
         ],
         "description": "Insert println!"
     },

--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -37,19 +37,19 @@
         "description": "Insert println!"
     },
     "assert": {
-		"prefix": "assert",
-		"body": [
-			"assert!($1)$0"
-		],
-		"description": "Insert assert!"
-	},
-	"assert_eq": {
-		"prefix": "assert_eq",
-		"body": [
-			"assert_eq!($1, $2)$0"
-		],
-		"description": "Insert assert_eq!"
-	},
+        "prefix": "assert",
+        "body": [
+            "assert!($1)$0"
+        ],
+        "description": "Insert assert!"
+    },
+    "assert_eq": {
+        "prefix": "assert_eq",
+        "body": [
+            "assert_eq!($1, $2)$0"
+        ],
+        "description": "Insert assert_eq!"
+    },
     "macro_rules": {
         "prefix": "macro_rules",
         "body": [


### PR DESCRIPTION
### 1. Add tabstop at the end for `println!` snippet.
With reference to an earlier pull request [#321](https://github.com/rust-lang-nursery/rls-vscode/pull/321) which added `assert!` and `assert_eq!` snippets, I think the `println!` snippet should be slightly tweaked to have a tabstop at the end. 

### 2. Fix source code formatting for `assert!` and `assert_eq!` snippets.
My apologies for an earlier pull request [#321](https://github.com/rust-lang-nursery/rls-vscode/pull/321)  which used incorrect tab spacing in the source code. I have changed it to use 4-space tabs now.