### PR TITLE
Recomend tslint extension for this workspace

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"eg2.tslint"
+	]
+}


### PR DESCRIPTION
Currently, it's very easy to make the linter unhappy (just forget a
semicolon), and then it's very hard to figure what's wrong (linter
errors are not shown in the editor, linter is only run by
`installDevExtensions`, and there its error messages are swallowed)

This commit adds tslint as a recommended extension for this VS Code
workspace. That is, new contributors will be prompted to install tslint
extension, and will see errors inline afterwards.