### PR TITLE
Add setting for clippy_preference

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,6 +311,17 @@
                     "description": "Enables code completion using racer.",
                     "scope": "resource"
                 },
+                "rust.clippy_preference": {
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "opt-in",
+                        "on"
+                    ],
+                    "default": "opt-in",
+                    "description": "Controls eagerness of clippy diagnostics when available.",
+                    "scope": "resource"
+                },
                 "rust.jobs": {
                     "type": [
                         "number",


### PR DESCRIPTION
Resolves #298.

By inspecting the vscode log files, I can confirm that it's receiving the setting properly, but I've yet to see any actual clippy lints when I have it set to "on."

Is there something else that needs to be done or am I just on a bad rls version?