### PR TITLE
Use fsPath for task cwd

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -58,7 +58,7 @@ function createTask({ definition, group, presentationOptions, problemMatcher }: 
 
     const execCmd = `${definition.command} ${definition.args.join(' ')}`;
     const execOption: ShellExecutionOptions = {
-        cwd: target.uri.path,
+        cwd: target.uri.fsPath,
         env: definition.env,
     };
     const exec = new ShellExecution(execCmd, execOption);


### PR DESCRIPTION
On Win10, trying to run the Tasks this exposes, I kept getting errors like  `Failed to create terminal: cargo build` , eventually checked it out in Procmon and saw it trying to open a path like `/c:/d:/myproj` (my project is at `D:/myproj`. I moved it to the `c:` drive to see if that would help, but it was still opening `/c:/myproj`.

Changing this to `fsPath` gets `c:/myproj` and the documentation seems to imply its probably the correct way to get a path string that will be passed to an OS API.