### PR TITLE
Avoid setting an invalid sysroot

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -344,6 +344,7 @@ class ClientWorkspace {
                 window.showWarningMessage(
                     'RLS could not set RUST_SRC_PATH for Racer because it could not read the Rust sysroot.'
                 );
+                return env;
             }
         }
 


### PR DESCRIPTION
If a sysroot was unable to be determined, don't modify the environment.