### PR TITLE
Use "Dedicated" instead of "New" panel when building tasks

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -186,7 +186,7 @@ export function runCommand(folder: WorkspaceFolder, cmd: Cmd): Thenable<TaskExec
         group: TaskGroup.Build,
         presentationOptions: {
             reveal: TaskRevealKind.Always,
-            panel: TaskPanelKind.New,
+            panel: TaskPanelKind.Dedicated,
         },
     };
     const task = createTask(config, folder);


### PR DESCRIPTION
It is required to press a key to close the terminal in vscode.

![image](https://user-images.githubusercontent.com/4198311/44299430-2df74800-a328-11e8-90ac-1c4365be5b92.png)

With current task settings, if I forget to close the terminal after seeing build information and keep building the project, there'll be hundreds of terminals in the background.

Therefore, I think it's better to use "Dedicated" instead of "New" in this setting. Each task occupies its own terminal, and there won't be so many terminals in the background.