### PR TITLE
Add snippets from vscode-rust

### DIFF
--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -78,5 +78,19 @@
             "});"
         ],
         "description": "Wrap code in thread::spawn"
+    },
+    "derive": {
+        "prefix": "derive",
+        "body": [
+            "#[derive(${1})]"
+        ],
+        "description": "#[derive(…)]"
+    },
+    "cfg": {
+        "prefix": "cfg",
+        "body": [
+            "#[cfg(${1})]"
+        ],
+        "description": "#[cfg(…)]"
     }
 }

--- a/snippets/rust.json
+++ b/snippets/rust.json
@@ -92,5 +92,15 @@
             "#[cfg(${1})]"
         ],
         "description": "#[cfg(…)]"
+    },
+    "test": {
+        "prefix": "test",
+        "body": [
+            "#[test]",
+            "fn ${1:name}() {",
+            "    ${2:unimplemented!();}",
+            "}"
+        ],
+        "description": "#[test]"
     }
 }


### PR DESCRIPTION
This adds snippets for cfg, derive, and test.