### PR TITLE
Use "Dedicated" instead of "New" panel when building tasks #2

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -81,7 +81,7 @@ function createTaskConfigItem(): Array<TaskConfigItem> {
 
     const presentationOptions: TaskPresentationOptions = {
         reveal: TaskRevealKind.Always,
-        panel: TaskPanelKind.New,
+        panel: TaskPanelKind.Dedicated,
     };
 
     const taskList: Array<TaskConfigItem> = [


### PR DESCRIPTION
Last time in #399 , I only fixed `cargo` command. Now all tasks are subject to Dedicated panel. Thanks @jens1o for reminding me.