### PR TITLE
Bump Travis Node to 8.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 language: node_js
 
 node_js:
-  - 8.9 # Sort with the version bundled in supported vscode.
+  - 8.9 # Lock to the version shipped with VSCode 1.26+
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,12 @@ notifications:
 language: node_js
 
 node_js:
-  - 7.4 # Sort with the version bundled in supported vscode.
+  - 8.9 # Sort with the version bundled in supported vscode.
 
 env:
   matrix:
     - CI_MATRIX_BUILD=true
     - CI_MATRIX_LINT=true
-
-before_install:
-  # Use npm@5 to use `package-lock.json`. After `node_js` field will be `8` or later.
-  # This process might be needless.
-  - npm upgrade npm@5 --global
-  - npm --version # to check TravisCI uses the expected version.
 
 script:
   - |


### PR DESCRIPTION
Fixes recent Travis failures.

With node 8.9 (what VSCode 1.26 seems to be shipping now) Travis ships an NPM 5.6 - that's the same what we get after running the global npm upgrade, so don't bother doing that anymore (per the removed now comment).

cc @saneyuki 