### PR TITLE
Improve documentation of the clippy_preference setting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
                         "off"
                     ],
                     "default": "opt-in",
-                    "description": "Controls eagerness of clippy diagnostics.",
+                    "description": "Controls eagerness of clippy diagnostics when available. Valid values are (case-insensitive):\n - \"off\": Disable clippy lints.\n - \"opt-in\": Clippy lints are shown when crates specify `#![warn(clippy)]`.\n - \"on\": Clippy lints enabled for all crates in workspace.\nYou need to install clippy via rustup if you haven't already.",
                     "scope": "resource"
                 },
                 "rust.jobs": {


### PR DESCRIPTION
Fixes #417.

There doesn't seem to be any way to include markup in the description.  I used back ticks to delimit code anyway, since I think it improves clarity, and it is done at other places in the same file.

The new description renders like this for me on VS Code 1.27.1:

![image](https://user-images.githubusercontent.com/249196/45180945-479bf900-b21d-11e8-8556-24b279c1d244.png)
