### PR TITLE
Adds an option for disabling Rustup

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,11 @@
                     "default": false,
                     "description": "Update the RLS whenever the extension starts up."
                 },
+                "rust-client.disableRustup": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disable usage of rustup and use rustc/rls from PATH."
+                },
                 "rust-client.channel": {
                     "type": [
                         "string",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -37,6 +37,10 @@ export class RLSConfiguration {
     public get logToFile(): boolean {
         return this.configuration.get<boolean>('rust-client.logToFile', false);
     }
+
+    public get rustupDisabled(): boolean {
+        return this.configuration.get<boolean>('rust-client.disableRustup', false);
+    }
     
     public get revealOutputChannelOn(): RevealOutputChannelOn {
         return RLSConfiguration.readRevealOutputChannelOn(this.configuration);

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -59,7 +59,7 @@ function createTask({ definition, group, presentationOptions, problemMatcher }: 
     const execCmd = `${definition.command} ${definition.args.join(' ')}`;
     const execOption: ShellExecutionOptions = {
         cwd: target.uri.fsPath,
-        env: definition.env,
+        env: Object.assign({}, process.env, definition.env),
     };
     const exec = new ShellExecution(execCmd, execOption);
 


### PR DESCRIPTION
If Rustup is disabled, rls/rustc will be used from PATH.
This is quite useful for systems that do not use any Rustup.